### PR TITLE
Remove language implying meritocratic attendance

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@ The importance and complexity of cryptographic software makes it an ideal applic
 for formal and high-assurance verification.  
 The Workshop on High Assurance Crypto Software (HACS) was launched in 2016
 by Gilles Barthe, Ben Laurie, and Trevor Perrin to drive this convergence forward.  
-As a yearly event, we’ve been bringing the world’s best cryptographic developers 
-(from open source and industry) together with top experts in formal verification and high assurance methodologies.  
+As a yearly event, we’ve been bringing cryptographic developers 
+(from open source and industry) together with experts in formal verification and high assurance methodologies.  
 The goal is to foster collaborations towards making cryptographic software flawless.
 </p>
 


### PR DESCRIPTION
The HACS website currently states:

> As a yearly event, we’ve been bringing the world’s best cryptographic developers (from open source and industry) together with top experts in formal verification and high assurance methodologies. 

HACS is not a meritocratic event; it is a closed event based on an opaque and unaccountable governance structure and attendance criteria. As such, it should not claim that it brings together "the world's best", "top experts", etc. since that is meritocratic language.

On the side, that language is also just obtuse and pretentious, and the organizers can probably do better.

This edit improves the text on the website to address this issue.

The language is [mirrored in this PDF](https://github.com/HACS-workshop/HACS-workshop.github.io/blob/master/data/HACS_2022_Overview.pdf) which I cannot create a pull request for since it is pretty much a binary blob.