### PR TITLE
Use correct name and abbreviation of MPI-SP, add missing link end tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ The following companies have supported or are supporting HACS:
 	  <ul id="lead-sponsors-box">
       <li><a href="https://www.amazon.com/"><p>Amazon</p></a></li>
       <li><a href="https://www.apple.com/"><p>Apple</p></a></li>
-      <li><a href="https://www.mpi-sp.org/"><p>Max Planck Institute (MPI)</p></a></li>
+      <li><a href="https://www.mpi-sp.org/"><p>Max Planck Institute for Security and Privacy (MPI-SP)</p></a></li>
 			<li><a href="https://www.oracle.com/"><p>Oracle</p></a></li>
 		</ul>
 	</div>
@@ -72,8 +72,8 @@ The following companies have supported or are supporting HACS:
 	  <p>Other sponsors:</p>
 	  <ul id="lead-sponsors-box">
       <li><a href="https://chaincode.com/"><p>Chaincode Labs</p></a></li>
-      <li><a href="https://www.cloudflare.com/"><p>CloudFlare</p></li>
-      <li><a href="https://paulkocher.com/"><p>Paul Kocher</p></li>
+		  <li><a href="https://www.cloudflare.com/"><p>CloudFlare</p></a></li>
+		  <li><a href="https://paulkocher.com/"><p>Paul Kocher</p></a></li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
The missing end tags made “Design by” link to Paul Kocher’s website, that’s how I noticed.